### PR TITLE
Minor Correction of YAML - Amending typos

### DIFF
--- a/code/API_definitions/CAMARA Device Identifier API.yaml
+++ b/code/API_definitions/CAMARA Device Identifier API.yaml
@@ -191,7 +191,7 @@ components:
               value:
                 status: 400
                 code: INVALID_ARGUMENT
-                message: "At least one of phoneNumber, networkAccessIdentifier, ipv4Address and ipv6Address msut be specified"
+                message: "At least one of phoneNumber, networkAccessIdentifier, ipv4Address and ipv6Address must be specified"
             InconsistentDeviceProperties:
               description: Device parameters provided identify different devices
               value:
@@ -232,7 +232,7 @@ components:
           examples:
             InvalidCredentials:
               value:
-                status: 400
+                status: 401
                 code: UNAUTHENTICATED
                 message: "Request not authenticated due to missing, invalid, or expired credentials"
 

--- a/code/API_definitions/CAMARA Device Identifier API.yaml
+++ b/code/API_definitions/CAMARA Device Identifier API.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: CAMARA Device Identifier API
-  version: 0.3.0
+  version: 0.3.1
   description: |
     # Summary
 


### PR DESCRIPTION
Corrected typos in YAML where the error code for InvalidCredentials is listed as 401, but in the example response, it is 400. For InsufficientParameters,  Message has a typo. "msut" instead of "must"


#### What type of PR is this?

Add one of the following kinds:
* bug
* correction


#### What this PR does / why we need it:

Corrects typos, so that adopters can be aligned in their deployments


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
